### PR TITLE
PBE_AssetsDownloader_v1.1.0.1-Beta

### DIFF
--- a/PBE_AssetsDownloader/Program.cs
+++ b/PBE_AssetsDownloader/Program.cs
@@ -58,7 +58,7 @@ namespace PBE_AssetsDownloader
 
                 // Crear una instancia de Resources para descargar los assets
                 var resourcesDownloader = new Resources(httpClient, directoryCreator); // Pasar directoryCreator aquí
-                await resourcesDownloader.DownloadAssetsAsync();
+                await resourcesDownloader.GetResourcesFiles();
 
                 Log.Information("Download complete.");
 

--- a/PBE_AssetsDownloader/Services/AssetDownloader.cs
+++ b/PBE_AssetsDownloader/Services/AssetDownloader.cs
@@ -18,7 +18,7 @@ namespace PBE_AssetsDownloader.Services
         {
             ".luabin", ".luabin64", ".preload", ".scb",
             ".sco", ".skl", ".mapgeo", ".subchunktoc", ".stringtable",
-            ".anm"
+            ".anm", ".dat", ".bnk", ".wpk"
         };
 
         public AssetDownloader(HttpClient httpClient, DirectoriesCreator directoriesCreator)

--- a/PBE_AssetsDownloader/Utils/DirectoryCreate.cs
+++ b/PBE_AssetsDownloader/Utils/DirectoryCreate.cs
@@ -56,6 +56,15 @@ namespace PBE_AssetsDownloader.Utils
 
         private string GetImageFolder(string fileName, string url)
         {
+            if (url.Contains("/summoneremotes/") || fileName.Contains(".accessories") || fileName.Contains("_accessories") || fileName.Contains("Inventory.TFT") || fileName.Contains("_inventory"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Emotes");
+            if (url.Contains("/profile-icons/"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Icons");
+            if (url.Contains("/champion-chroma-images/"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Chromas");
+            if (url.Contains("/loadingscreen/"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "LoadingScreen");
+            
             if (url.Contains("/hud/") && (fileName.Contains("circle") || fileName.Contains("square")))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Hud");
             if (fileName.Contains("loadscreen_") || fileName.Contains("loadscreen"))
@@ -64,21 +73,24 @@ namespace PBE_AssetsDownloader.Utils
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Skins", "SplashArts");
             if (url.Contains("/skins/") && url.Contains("/particles/"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Skins", "Particles");
-            if (url.Contains("/skins/") && (fileName.Contains("2x_") || fileName.Contains("4x_") || fileName.Contains("_skin")))
+            if (url.Contains("/skins/") && (fileName.Contains("2x_") || fileName.Contains("4x_") || fileName.Contains("_skin") || fileName.Contains("_base")))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Skins");
-            if (url.Contains("tft"))
-                return Path.Combine(SubAssetsDownloadedPath, "Images", "TFT");
             if (url.Contains("/regalia/"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Banners");
-            if ((url.Contains("/maps/") && (fileName.Contains("_env_update") || fileName.Contains("_env"))) || url.Contains("/terrainpaint/"))
+            if (url.Contains("/maps/") && (url.Contains("/srs/") || (fileName.Contains("_env_update") || fileName.Contains("_env"))) || url.Contains("/terrainpaint/"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Maps");
+
+            if (url.Contains("/maps/") && (url.Contains("/tft/") || (url.Contains("/mapgeometry/"))))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "TFT", "Maps");
+            if (url.Contains("tft"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "TFT");
+                
             if (url.Contains("/maps/particles/"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Maps", "Particles");
             if (url.Contains("/shared/particles/"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Shared", "Particles");
-            if (url.Contains("/summoneremotes/") && fileName.Contains(".accessories"))
-                return Path.Combine(SubAssetsDownloadedPath, "Images", "Emotes");
 
+                
             return Path.Combine(SubAssetsDownloadedPath, "Images");
         }
 

--- a/PBE_AssetsDownloader/Utils/Resources.cs
+++ b/PBE_AssetsDownloader/Utils/Resources.cs
@@ -20,7 +20,7 @@ namespace PBE_AssetsDownloader.Utils
             _assetDownloader = new AssetDownloader(_httpClient, directoryCreator);
         }
 
-        public async Task DownloadAssetsAsync()
+        public async Task GetResourcesFiles()
         {
             var directoryCreator = new DirectoriesCreator();
             await directoryCreator.CreateDirAssetsDownloadedAsync();


### PR DESCRIPTION
# PBE_AssetsDownloader - League of Legends | Minor Update v.1.1.0.1-Beta

# [IMPROVEMENTS]
- Other extensions have been added to prevent downloading.
- Emotes and other assets have been improved in their organization.
- The reference packs have been updated in their version.

**Note: Asset organization will be an ongoing process, as there are many variables to keep in mind
to keep all assets organized.**