### PR TITLE
Medium Update v1.1.1.0-Beta

### DIFF
--- a/PBE_AssetsDownloader/Services/HashesManager.cs
+++ b/PBE_AssetsDownloader/Services/HashesManager.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace PBE_AssetsDownloader.Services
 {
@@ -11,36 +13,118 @@ namespace PBE_AssetsDownloader.Services
         private readonly string _oldHashesDirectory;
         private readonly string _newHashesDirectory;
         private readonly string _resourcesPath;
+        private readonly List<string> _excludedExtensions;
 
         // Modificar constructor para aceptar resourcesPath
-        public HashesManager(string oldHashesDirectory, string newHashesDirectory, string resourcesPath)
+        public HashesManager(string oldHashesDirectory, string newHashesDirectory, string resourcesPath, List<string> excludedExtensions)
         {
             _oldHashesDirectory = oldHashesDirectory;
             _newHashesDirectory = newHashesDirectory;
             _resourcesPath = resourcesPath;
+            _excludedExtensions = excludedExtensions;
         }
 
         public async Task CompareHashesAsync()
         {
+            // Mensaje indicando que estamos revisando y filtrando hashes
+            Log.Information("Comparing and filtering hashes, please wait...");
+
             // Combina las rutas usando los directorios proporcionados
             string oldGameHashesPath = Path.Combine(_oldHashesDirectory, "hashes.game.txt");
             string oldLcuHashesPath = Path.Combine(_oldHashesDirectory, "hashes.lcu.txt");
             string newGameHashesPath = Path.Combine(_newHashesDirectory, "hashes.game.txt");
             string newLcuHashesPath = Path.Combine(_newHashesDirectory, "hashes.lcu.txt");
 
-            // Lee los archivos de hashes
-            var oldGameHashes = await File.ReadAllLinesAsync(oldGameHashesPath);
-            var oldLcuHashes = await File.ReadAllLinesAsync(oldLcuHashesPath);
-            var newGameHashes = await File.ReadAllLinesAsync(newGameHashesPath);
-            var newLcuHashes = await File.ReadAllLinesAsync(newLcuHashesPath);
+            // Lee los archivos de hashes de forma asíncrona
+            var oldGameHashesTask = File.ReadAllLinesAsync(oldGameHashesPath);
+            var oldLcuHashesTask = File.ReadAllLinesAsync(oldLcuHashesPath);
+            var newGameHashesTask = File.ReadAllLinesAsync(newGameHashesPath);
+            var newLcuHashesTask = File.ReadAllLinesAsync(newLcuHashesPath);
 
-            // Compara los hashes
-            var differencesGame = newGameHashes.Except(oldGameHashes).ToList();
-            var differencesLcu = newLcuHashes.Except(oldLcuHashes).ToList();
+            await Task.WhenAll(oldGameHashesTask, oldLcuHashesTask, newGameHashesTask, newLcuHashesTask);
 
-            // Guarda las diferencias en los archivos correspondientes dentro del directorio de recursos
-            await File.WriteAllLinesAsync(Path.Combine(_resourcesPath, "differences_game.txt"), differencesGame);
+            var oldGameHashes = await oldGameHashesTask;
+            var oldLcuHashes = await oldLcuHashesTask;
+            var newGameHashes = await newGameHashesTask;
+            var newLcuHashes = await newLcuHashesTask;
+
+            // Convertir oldHashes a HashSet para mejorar la búsqueda
+            var oldGameHashesSet = new HashSet<string>(oldGameHashes);
+            var oldLcuHashesSet = new HashSet<string>(oldLcuHashes);
+
+            // Comparar hashes en paralelo
+            var differencesGame = new ConcurrentBag<string>();
+            var differencesLcu = new ConcurrentBag<string>();
+
+            Parallel.ForEach(newGameHashes, newHash =>
+            {
+                if (!oldGameHashesSet.Contains(newHash))
+                {
+                    differencesGame.Add(newHash);
+                }
+            });
+
+            Parallel.ForEach(newLcuHashes, newHash =>
+            {
+                if (!oldLcuHashesSet.Contains(newHash))
+                {
+                    differencesLcu.Add(newHash);
+                }
+            });
+
+            // Llamar al método de filtrado para las diferencias de Game
+            await FilterAndSaveDifferencesAsync(differencesGame.ToList(), differencesLcu.ToList());
+        }
+
+        // Método para filtrar y guardar las diferencias después de eliminar duplicados .tex
+        public async Task FilterAndSaveDifferencesAsync(List<string> differencesGame, List<string> differencesLcu)
+        {
+            // Lee los hashes antiguos de 'hashes.game.txt'
+            string oldHashesPath = Path.Combine(_oldHashesDirectory, "hashes.game.txt");
+            var oldHashes = await File.ReadAllLinesAsync(oldHashesPath);
+            
+            // Convertir oldHashes a HashSet para mejorar la búsqueda
+            var oldHashesSet = new HashSet<string>(oldHashes);
+
+            // Filtrar las líneas que terminan en .tex o están en la lista de extensiones excluidas
+            var filteredDifferencesGame = new List<string>();
+
+            foreach (var line in differencesGame)
+            {
+                var parts = line.Split(' ');
+                var filePath = parts[1]; // Asumiendo que la ruta está en la segunda posición
+
+                // Verificamos si la extensión del archivo está en la lista de exclusiones
+                var fileExtension = Path.GetExtension(filePath);
+                if (_excludedExtensions.Contains(fileExtension))
+                {
+                    continue;  // Excluir si está en las extensiones excluidas
+                }
+
+                if (filePath.EndsWith(".tex"))
+                {
+                    // Extraemos el nombre base del archivo .tex (sin la extensión)
+                    string baseFilePath = filePath.Replace(".tex", "");
+                    // Verificamos si ya existe en los viejos hashes
+                    bool foundInOldHashes = oldHashesSet.Any(oldHash => oldHash.Contains(baseFilePath));
+                    // Si no existe en los viejos hashes, lo añadimos a las diferencias filtradas
+                    if (!foundInOldHashes)
+                    {
+                        filteredDifferencesGame.Add(line);  // Agregar si no está en los viejos hashes
+                    }
+                }
+                else
+                {
+                    filteredDifferencesGame.Add(line);  // Agregar si no es un archivo .tex
+                }
+            }
+
+            // Guardar las diferencias filtradas
+            await File.WriteAllLinesAsync(Path.Combine(_resourcesPath, "differences_game.txt"), filteredDifferencesGame);
             await File.WriteAllLinesAsync(Path.Combine(_resourcesPath, "differences_lcu.txt"), differencesLcu);
+
+            Log.Information("Filtered differences saved to {0}", Path.Combine(_resourcesPath, "differences_game.txt"));
+            Log.Information("Filtered differences saved to {0}", Path.Combine(_resourcesPath, "differences_lcu.txt"));
         }
     }
 }

--- a/PBE_AssetsDownloader/UI/MainForm.cs
+++ b/PBE_AssetsDownloader/UI/MainForm.cs
@@ -14,18 +14,20 @@ namespace PBE_AssetsDownloader.UI
     {
         private bool _syncHashesWithCDTB; // Indica si se debe sincronizar con CDTB
         private bool _autoCopyHashes; // Indica si se debe copiar automáticamente los hashes
+        private bool _createBackUpOldHashes; // Indica si se debe crear una copia de seguridad de los hashes antiguos
         private Status _status; // Instancia para manejar el estado del servidor
 
         public MainForm()
         {
             InitializeComponent();
             ApplicationInfos.SetInfo(this);
-            
+
             _status = new Status(AppendLog);
 
             var settings = LoadSettings();
             _syncHashesWithCDTB = settings.syncHashesWithCDTB;
             _autoCopyHashes = settings.AutoCopyHashes;
+            _createBackUpOldHashes = settings.CreateBackUpOldHashes;
 
             if (_syncHashesWithCDTB)
             {
@@ -34,7 +36,11 @@ namespace PBE_AssetsDownloader.UI
             }
             if (_autoCopyHashes)
             {
-                AppendLog("Copy Hashes automatically enabled.");
+                AppendLog("Automatically replace old hashes enabled.");
+            }
+            if (_createBackUpOldHashes)
+            {
+                AppendLog("Backup old hashes enabled.");
             }
         }
 
@@ -76,12 +82,11 @@ namespace PBE_AssetsDownloader.UI
                 return;
             }
 
-            string result = await Program.RunExtraction(newHashesTextBox.Text, oldHashesTextBox.Text, _syncHashesWithCDTB, _autoCopyHashes, logMessage =>
+            // Llamada sin esperar un retorno (ahora el método solo se ejecuta y se loguea la salida)
+            await Program.RunExtraction(newHashesTextBox.Text, oldHashesTextBox.Text, _syncHashesWithCDTB, _autoCopyHashes, _createBackUpOldHashes, logMessage =>
             {
                 AppendLog(logMessage); // Utilizar AppendLog para agregar el mensaje con margen
             });
-
-            AppendLog(result);
         }
 
         private void btnHelp_Click(object sender, EventArgs e)
@@ -95,7 +100,7 @@ namespace PBE_AssetsDownloader.UI
         // Abre la ventana de configuración
         private void btnSettings_Click(object sender, EventArgs e)
         {
-            using (var settingsForm = new SettingsForm(_syncHashesWithCDTB, _autoCopyHashes, _status))
+            using (var settingsForm = new SettingsForm(_syncHashesWithCDTB, _autoCopyHashes, _createBackUpOldHashes, _status))
             {
                 // Suscribirse al evento SettingsChanged
                 settingsForm.SettingsChanged += OnSettingsChanged;
@@ -103,12 +108,14 @@ namespace PBE_AssetsDownloader.UI
                 {
                     bool newsyncHashesWithCDTB = settingsForm.syncHashesWithCDTB;
                     bool newAutoCopyHashes = settingsForm.AutoCopyHashes;
+                    bool newCreateBackUpOldHashes = settingsForm.CreateBackUpOldHashes;
 
-                    if (newsyncHashesWithCDTB != _syncHashesWithCDTB || newAutoCopyHashes != _autoCopyHashes)
+                    if (newsyncHashesWithCDTB != _syncHashesWithCDTB || newAutoCopyHashes != _autoCopyHashes || newCreateBackUpOldHashes != _createBackUpOldHashes)
                     {
                         _syncHashesWithCDTB = newsyncHashesWithCDTB;
                         _autoCopyHashes = newAutoCopyHashes;
-                        SaveSettings(_syncHashesWithCDTB, _autoCopyHashes.ToString());
+                        _createBackUpOldHashes = newCreateBackUpOldHashes;
+                        SaveSettings(_syncHashesWithCDTB, _autoCopyHashes, _createBackUpOldHashes);
                         AppendLog("Settings updated.");
                     }
                 }
@@ -122,6 +129,7 @@ namespace PBE_AssetsDownloader.UI
             var settings = LoadSettings();
             _syncHashesWithCDTB = settings.syncHashesWithCDTB;
             _autoCopyHashes = settings.AutoCopyHashes;
+            _createBackUpOldHashes = settings.CreateBackUpOldHashes;
         }
 
         private async Task SyncHashesOnly()
@@ -142,11 +150,12 @@ namespace PBE_AssetsDownloader.UI
             }
         }
 
-        private void SaveSettings(bool syncHashesWithCDTB, string autoCopyHashes, string lastUpdateHashes = null)
+        private void SaveSettings(bool syncHashesWithCDTB, bool autoCopyHashes, bool createBackUpOldHashes, string lastUpdateHashes = null)
         {
             var settings = LoadSettings();
             settings.syncHashesWithCDTB = syncHashesWithCDTB;
-            settings.AutoCopyHashes = bool.Parse(autoCopyHashes);
+            settings.AutoCopyHashes = autoCopyHashes;
+            settings.CreateBackUpOldHashes = createBackUpOldHashes;
 
             if (!string.IsNullOrEmpty(lastUpdateHashes))
             {
@@ -159,7 +168,7 @@ namespace PBE_AssetsDownloader.UI
 
         private void AppendLog(string message)
         {
-            if (richTextBoxLogs.InvokeRequired) // o richTextBoxContent según el formulario
+            if (richTextBoxLogs.InvokeRequired) 
             {
                 richTextBoxLogs.Invoke(new Action(() => 
                 {
@@ -188,7 +197,7 @@ namespace PBE_AssetsDownloader.UI
                 return JsonConvert.DeserializeObject<AppSettings>(json) ?? new AppSettings();
             }
 
-            return new AppSettings { syncHashesWithCDTB = false, AutoCopyHashes = false };
+            return new AppSettings { syncHashesWithCDTB = false, AutoCopyHashes = false, CreateBackUpOldHashes = false };
         }
 
         public class AppSettings
@@ -196,6 +205,7 @@ namespace PBE_AssetsDownloader.UI
             public bool syncHashesWithCDTB { get; set; }
             public string lastUpdateHashes { get; set; }
             public bool AutoCopyHashes { get; set; }
+            public bool CreateBackUpOldHashes { get; set; }
         }
     }
 }

--- a/PBE_AssetsDownloader/UI/SettingsForm.Designer.cs
+++ b/PBE_AssetsDownloader/UI/SettingsForm.Designer.cs
@@ -5,12 +5,14 @@ namespace PBE_AssetsDownloader.UI
         private System.Windows.Forms.Button btnSave;
         private System.Windows.Forms.CheckBox checkBoxSyncHashes;
         private System.Windows.Forms.CheckBox checkBoxAutoCopy;
+        private System.Windows.Forms.CheckBox CheckBoxCreateBackUp;
         private System.Windows.Forms.RichTextBox richTextBoxLogs; // Cambiado a RichTextBox
 
         private void InitializeComponent()
         {
             this.checkBoxSyncHashes = new System.Windows.Forms.CheckBox();
             this.checkBoxAutoCopy = new System.Windows.Forms.CheckBox();
+            this.CheckBoxCreateBackUp = new System.Windows.Forms.CheckBox();
             this.btnSave = new System.Windows.Forms.Button();
             this.richTextBoxLogs = new System.Windows.Forms.RichTextBox(); // Inicialización del RichTextBox
 
@@ -35,8 +37,19 @@ namespace PBE_AssetsDownloader.UI
             this.checkBoxAutoCopy.Name = "checkBoxAutoCopy";
             this.checkBoxAutoCopy.Size = new System.Drawing.Size(250, 24);
             this.checkBoxAutoCopy.TabIndex = 1;
-            this.checkBoxAutoCopy.Text = "Automatically copy new hashes to old";
+            this.checkBoxAutoCopy.Text = "Automatically replace old hashes";
             this.checkBoxAutoCopy.UseVisualStyleBackColor = true;
+            
+            // 
+            // CheckBoxCreateBackUp
+            // 
+            this.CheckBoxCreateBackUp.AutoSize = true;
+            this.CheckBoxCreateBackUp.Location = new System.Drawing.Point(12, 48);
+            this.CheckBoxCreateBackUp.Name = "CheckBoxCreateBackUp";
+            this.CheckBoxCreateBackUp.Size = new System.Drawing.Size(250, 24);
+            this.CheckBoxCreateBackUp.TabIndex = 1;
+            this.CheckBoxCreateBackUp.Text = "Create backup old hashes";
+            this.CheckBoxCreateBackUp.UseVisualStyleBackColor = true;
 
             // 
             // richTextBoxLogs
@@ -72,6 +85,7 @@ namespace PBE_AssetsDownloader.UI
             this.ClientSize = new System.Drawing.Size(284, 261);
             this.Controls.Add(this.checkBoxAutoCopy);
             this.Controls.Add(this.checkBoxSyncHashes);
+            this.Controls.Add(this.CheckBoxCreateBackUp);
             this.Controls.Add(this.richTextBoxLogs);
             this.Controls.Add(this.btnSave);
             this.Name = "SettingsForm";

--- a/PBE_AssetsDownloader/UI/SettingsForm.cs
+++ b/PBE_AssetsDownloader/UI/SettingsForm.cs
@@ -18,11 +18,12 @@ namespace PBE_AssetsDownloader.UI
 
         public bool syncHashesWithCDTB { get; private set; }
         public bool AutoCopyHashes { get; private set; }
+        public bool CreateBackUpOldHashes { get; private set; }
 
         // Evento para notificar cambios en la configuración
         public event EventHandler SettingsChanged;
 
-        public SettingsForm(bool syncHashesWithCDTB, bool autoCopyHashes, Status status)
+        public SettingsForm(bool syncHashesWithCDTB, bool autoCopyHashes, bool CreateBackUpOldHashes, Status status)
         {
             InitializeComponent();
             ApplicationInfos.SetIcon(this);
@@ -38,16 +39,21 @@ namespace PBE_AssetsDownloader.UI
 
             this.AutoCopyHashes = settings.AutoCopyHashes;
             checkBoxAutoCopy.Checked = AutoCopyHashes;
+            
+            this.CreateBackUpOldHashes = settings.CreateBackUpOldHashes;
+            CheckBoxCreateBackUp.Checked = CreateBackUpOldHashes;
         }
 
         private async void btnSave_Click(object sender, EventArgs e)
         {
             syncHashesWithCDTB = checkBoxSyncHashes.Checked;
             AutoCopyHashes = checkBoxAutoCopy.Checked;
+            CreateBackUpOldHashes = CheckBoxCreateBackUp.Checked;
 
             var settings = LoadSettings();
             settings.syncHashesWithCDTB = syncHashesWithCDTB;
             settings.AutoCopyHashes = AutoCopyHashes;
+            settings.CreateBackUpOldHashes = CreateBackUpOldHashes;
 
             SaveSettings(settings.syncHashesWithCDTB, settings.lastUpdateHashes);
 
@@ -105,7 +111,7 @@ namespace PBE_AssetsDownloader.UI
                 return JsonConvert.DeserializeObject<AppSettings>(json);
             }
 
-            return new AppSettings { syncHashesWithCDTB = false, AutoCopyHashes = false };
+            return new AppSettings { syncHashesWithCDTB = false, AutoCopyHashes = false, CreateBackUpOldHashes = false };
         }
 
         private void SaveSettings(bool syncHashesWithCDTB, string lastUpdateHashes = null)
@@ -113,6 +119,7 @@ namespace PBE_AssetsDownloader.UI
             var settings = LoadSettings();
             settings.syncHashesWithCDTB = syncHashesWithCDTB;
             settings.AutoCopyHashes = AutoCopyHashes;
+            settings.CreateBackUpOldHashes = CreateBackUpOldHashes;
 
             if (!string.IsNullOrEmpty(lastUpdateHashes))
             {
@@ -150,6 +157,7 @@ namespace PBE_AssetsDownloader.UI
             public bool syncHashesWithCDTB { get; set; }
             public string lastUpdateHashes { get; set; }
             public bool AutoCopyHashes { get; set; }
+            public bool CreateBackUpOldHashes { get; set; }
         }
     }
 }

--- a/PBE_AssetsDownloader/Utils/DirectoryCreate.cs
+++ b/PBE_AssetsDownloader/Utils/DirectoryCreate.cs
@@ -12,8 +12,8 @@ namespace PBE_AssetsDownloader.Utils
 
         public DirectoriesCreator()
         {
-            SubAssetsDownloadedPath = Path.Combine("AssetsDownloaded", DateTime.Now.ToString("dd-M-yyyy--HH-mm"));
-            ResourcesPath = Path.Combine("Resources", DateTime.Now.ToString("yyyy-MM-dd--HH-mm"));
+            SubAssetsDownloadedPath = Path.Combine("AssetsDownloaded", DateTime.Now.ToString("dd-M-yyyy"));
+            ResourcesPath = Path.Combine("Resources", DateTime.Now.ToString("dd-M-yyyy"));
         }
 
         public Task CreateDirResourcesAsync() => CreateFoldersAsync(ResourcesPath);
@@ -22,7 +22,11 @@ namespace PBE_AssetsDownloader.Utils
 
         public Task CreateHashesNewDirectoryAsync() => CreateFoldersAsync(Path.Combine("hashes", "new"));
 
+        public Task CreateBackUpOldHashesAsync() => CreateFoldersAsync(Path.Combine("hashes", "olds", "BackUp", DateTime.Now.ToString("dd-M-yyyy")));
+
         public string GetHashesNewsDirectoryPath() => Path.Combine("hashes", "new");
+
+        public string GetBackUpOldHashesPath() => Path.Combine("hashes", "olds", "BackUp", DateTime.Now.ToString("dd-M-yyyy"));
 
         public async Task CreateAllDirectoriesAsync()
         {
@@ -58,40 +62,84 @@ namespace PBE_AssetsDownloader.Utils
         {
             if (url.Contains("/summoneremotes/") || fileName.Contains(".accessories") || fileName.Contains("_accessories") || fileName.Contains("Inventory.TFT") || fileName.Contains("_inventory"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Emotes");
+            
             if (url.Contains("/profile-icons/"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Icons");
+            
+            if (url.Contains("/ux") && (url.Contains("/teamicons/")))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Others Icons");
+            
             if (url.Contains("/champion-chroma-images/"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Chromas");
+            
             if (url.Contains("/loadingscreen/"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "LoadingScreen");
             
             if (url.Contains("/hud/") && (fileName.Contains("circle") || fileName.Contains("square")))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Hud");
+            
             if (fileName.Contains("loadscreen_") || fileName.Contains("loadscreen"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Skins", "LoadScreen");
-            if (fileName.Contains("splash_centered") || fileName.Contains("splash_tile") || fileName.Contains("splash_uncentered"))
+            
+            if (url.Contains("/tft") && (fileName.Contains("splash_tile") || fileName.Contains("splash_uncentered") || fileName.Contains("splash_centered")))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Skins", "SplashArts", "TFT");
+            
+            if (url.Contains("plugins") && (fileName.Contains("splash_centered") || fileName.Contains("splash_tile") || fileName.Contains("splash_uncentered")))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Skins", "SplashArts");
+            
             if (url.Contains("/skins/") && url.Contains("/particles/"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Skins", "Particles");
+            
+            if (url.Contains("/skins/") && (url.Contains("skinfeaturespreview")))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Skins", "Exalted");
+            
             if (url.Contains("/skins/") && (fileName.Contains("2x_") || fileName.Contains("4x_") || fileName.Contains("_skin") || fileName.Contains("_base")))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Skins");
+            
             if (url.Contains("/regalia/"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Banners");
-            if (url.Contains("/maps/") && (url.Contains("/srs/") || (fileName.Contains("_env_update") || fileName.Contains("_env"))) || url.Contains("/terrainpaint/"))
+            
+            if (url.Contains("/maps/") && (url.Contains("/kitpieces") && url.Contains("/textures/")))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Maps", "Textures");
+            
+            if (url.Contains("/maps/") && url.Contains("/kitpieces"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Maps");
-
-            if (url.Contains("/maps/") && (url.Contains("/tft/") || (url.Contains("/mapgeometry/"))))
-                return Path.Combine(SubAssetsDownloadedPath, "Images", "TFT", "Maps");
+            
+            if (url.Contains("/maps/") && (url.Contains("/srs/") || fileName.Contains("_env_update") || fileName.Contains("_env")) || url.Contains("/terrainpaint/"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Maps");
+            
+            if (url.Contains("levels/"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Maps");
+            
+            if (url.Contains("/maps/") && url.Contains("/mapgeometry/"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Maps");
+            
             if (url.Contains("tft"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "TFT");
                 
             if (url.Contains("/maps/particles/"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Maps", "Particles");
+            
             if (url.Contains("/shared/particles/"))
                 return Path.Combine(SubAssetsDownloadedPath, "Images", "Shared", "Particles");
-
-                
-            return Path.Combine(SubAssetsDownloadedPath, "Images");
+            
+            if (url.Contains("/augments/") && url.Contains("/icons/"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Augments");
+            
+            if (url.Contains("/augments/") && url.Contains("/statanvil/"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Augments", "Statanvil");
+            
+            if (url.Contains("/companions/"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Companions");
+            
+            if (url.Contains("/loot/"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Loot");
+            
+            if (url.Contains("/seasons/"))
+                return Path.Combine(SubAssetsDownloadedPath, "Images", "Seasons");
+            
+            // Si ninguna de las condiciones anteriores se cumple, clasificar como "Unclassified"
+            return Path.Combine(SubAssetsDownloadedPath, "Images", "Unclassified");
         }
 
         private static Task CreateFoldersAsync(string path)

--- a/PBE_AssetsDownloader/Utils/HashBackUp.cs
+++ b/PBE_AssetsDownloader/Utils/HashBackUp.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace PBE_AssetsDownloader.Utils
+{
+    public class BackUp
+    {
+        private readonly DirectoriesCreator _directoriesCreator;
+
+        public BackUp(DirectoriesCreator directoriesCreator)
+        {
+            _directoriesCreator = directoriesCreator;
+        }
+
+        public async Task<string> HandleBackUpAsync(bool createBackUp)
+        {
+            if (createBackUp)
+            {
+                // Copiar archivos específicos a la carpeta de respaldo ya creada
+                return await CopyFilesToBackUp();
+            }
+            else
+            {
+                Log.Information("BackUpOldHashes is disabled.");  // Solo el log, sin devolver el mensaje
+                return string.Empty;  // Puedes devolver un string vacío o algún otro valor si no es necesario
+            }
+        }
+
+        public async Task<string> CopyFilesToBackUp()
+        {
+            try
+            {
+                // Obtén la ruta del directorio de respaldo desde DirectoriesCreator
+                await _directoriesCreator.CreateBackUpOldHashesAsync(); // Solo espera a que el directorio sea creado
+
+                // Obtén la ruta del directorio old
+                string oldDirectory = Path.Combine("hashes", "olds");
+
+                // La ruta de la carpeta de respaldo es la que se crea en CreateBackUpOldHashesAsync
+                //string backupDirectory = Path.Combine("hashes", "olds", "BackUp", DateTime.Now.ToString("dd-M-yyyy"));
+                
+                // Obtén la ruta del directorio de respaldo desde DirectoriesCreator
+                string backupDirectory = _directoriesCreator.GetBackUpOldHashesPath();
+
+                // Verifica que el directorio de respaldo exista antes de copiar
+                if (!Directory.Exists(backupDirectory))
+                {
+                    return "Backup directory does not exist";
+                }
+
+                // Definir los archivos específicos que se deben copiar
+                var filesToCopy = new[] { "hashes.game.txt", "hashes.lcu.txt" };
+
+                foreach (var fileName in filesToCopy)
+                {
+                    string sourceFilePath = Path.Combine(oldDirectory, fileName);
+                    string destinationFilePath = Path.Combine(backupDirectory, fileName);
+
+                    // Verificar que el archivo de origen exista antes de copiar
+                    if (File.Exists(sourceFilePath))
+                    {
+                        // Copiar el archivo
+                        File.Copy(sourceFilePath, destinationFilePath, true);
+                        //Log.Information("File {0} copied to backup directory.", fileName);
+                    }
+                }
+
+                Log.Information("Backup created successfully at {0}", backupDirectory);
+                return backupDirectory;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error occurred while creating backup");
+                return "Error occurred while creating backup";
+            }
+        }
+    }
+}

--- a/PBE_AssetsDownloader/Utils/HashCopier.cs
+++ b/PBE_AssetsDownloader/Utils/HashCopier.cs
@@ -1,62 +1,101 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace PBE_AssetsDownloader.Utils
 {
     public class HashCopier
     {
+        public async Task<string> HandleCopyAsync(bool autoCopyHashes, string sourcePath, string destinationPath)
+        {
+            if (autoCopyHashes)
+            {
+                // Iniciar el proceso de copia de hashes
+                return await CopyNewHashesToOlds(sourcePath, destinationPath);
+            }
+            else
+            {
+                Log.Information("AutoCopyHashes is disabled.");
+                return string.Empty; // Retornar cadena vacía si autoCopyHashes está deshabilitado
+            }
+        }
+
         public async Task<string> CopyNewHashesToOlds(string sourcePath, string destinationPath)
         {
-            if (Directory.Exists(sourcePath))
+            // Verificar si el directorio fuente existe
+            if (!Directory.Exists(sourcePath))
             {
-                // Elimina el directorio de destino si existe
-                if (Directory.Exists(destinationPath))
-                {
-                    Directory.Delete(destinationPath, true);
-                }
-
-                // Copia el directorio
-                await Task.Run(() => DirectoryCopy(sourcePath, destinationPath, true));
-
-                // Devuelve el mensaje de éxito
-                return "Hashes replaced successfully.";
+                Log.Error("Source directory does not exist: {0}", sourcePath);
+                return "Hashes were not replaced because the source directory does not exist.";
             }
 
-            // Devuelve el mensaje de fracaso si el directorio fuente no existe
-            return "Hashes were not replaced because the source directory does not exist.";
+            try
+            {
+                // Verificar si el directorio de destino existe
+                if (!Directory.Exists(destinationPath))
+                {
+                    // Si no existe, crear el directorio de destino
+                    Directory.CreateDirectory(destinationPath);
+                    Log.Information("Destination directory did not exist and was created: {0}", destinationPath);
+                }
+
+                // Copiar los archivos y subdirectorios desde el directorio fuente al destino, sobrescribiendo si es necesario
+                await Task.Run(() => DirectoryCopy(sourcePath, destinationPath, true));
+
+                // Verificar que el directorio de destino existe después de la copia
+                if (Directory.Exists(destinationPath))
+                {
+                    Log.Information("Hashes replaced successfully.");
+                    return "Hashes replaced successfully.";
+                }
+                else
+                {
+                    Log.Error("Destination directory was not created: {0}", destinationPath);
+                    return "Failed to replace hashes: destination directory not created.";
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "An error occurred while copying hashes.");
+                return "An error occurred while copying hashes.";
+            }
         }
 
         private void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs)
         {
-            DirectoryInfo dir = new DirectoryInfo(sourceDirName);
-            DirectoryInfo[] dirs = dir.GetDirectories();
-
-            // Si el directorio fuente no existe, lanza una excepción
-            if (!dir.Exists)
+            try
             {
-                throw new DirectoryNotFoundException("Source directory does not exist or could not be found: " + sourceDirName);
-            }
+                DirectoryInfo dir = new DirectoryInfo(sourceDirName);
+                if (!dir.Exists)
+                    throw new DirectoryNotFoundException($"Source directory does not exist: {sourceDirName}");
 
-            // Si el directorio de destino no existe, créalo
-            Directory.CreateDirectory(destDirName);
+                // Crear el directorio de destino si no existe
+                Directory.CreateDirectory(destDirName);
 
-            // Obtiene los archivos en el directorio y los copia al nuevo destino
-            FileInfo[] files = dir.GetFiles();
-            foreach (FileInfo file in files)
-            {
-                string temppath = Path.Combine(destDirName, file.Name);
-                file.CopyTo(temppath, false);
-            }
-
-            // Si se deben copiar subdirectorios, cópialos y sus contenidos al nuevo destino
-            if (copySubDirs)
-            {
-                foreach (DirectoryInfo subdir in dirs)
+                // Copiar los archivos
+                FileInfo[] files = dir.GetFiles();
+                foreach (FileInfo file in files)
                 {
-                    string temppath = Path.Combine(destDirName, subdir.Name);
-                    DirectoryCopy(subdir.FullName, temppath, copySubDirs);
+                    string tempPath = Path.Combine(destDirName, file.Name);
+                    file.CopyTo(tempPath, true); // Sobrescribir archivos si ya existen
                 }
+
+                // Copiar subdirectorios si se permite
+                if (copySubDirs)
+                {
+                    DirectoryInfo[] subdirs = dir.GetDirectories();
+                    foreach (DirectoryInfo subdir in subdirs)
+                    {
+                        string tempPath = Path.Combine(destDirName, subdir.Name);
+                        DirectoryCopy(subdir.FullName, tempPath, copySubDirs);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error copying directory.");
+                throw new InvalidOperationException("Error copying directory", ex);
             }
         }
     }

--- a/PBE_AssetsDownloader/Utils/Resources.cs
+++ b/PBE_AssetsDownloader/Utils/Resources.cs
@@ -70,6 +70,7 @@ namespace PBE_AssetsDownloader.Utils
             // Modificar las URLs no encontradas para los Game Assets
             var modifiedNotFoundGameAssets = notFoundGameAssets
                 .Select(url => url.EndsWith(".dds") ? url.Replace(".dds", ".png") : url)
+                .Select(url => url.EndsWith(".tex") ? url.Replace(".tex", ".png") : url)
                 .ToList();
 
             // Combinar todas las URLs no encontradas


### PR DESCRIPTION
New features, improvements, and bug fixes are added.

- In the latest Riot updates, the same assets were added with different ".tex" extensions, as assets with the ".dds" extension already existed. Therefore, a filter has been added to prevent re-downloading of previously existing assets.
- A new option has been added to back up your old hashes.
- Improved hash comparison and filtering time (High: 5 minutes to Low: 3 minutes) depending on the size of the updates.
- Added some assets for download, as they were ignored in recent updates.
- Added .tex assets converted to .png to NotFounds to facilitate the URL directly.
- Added some assets that were not downloading.
- Improved asset organization.
- Fixed a bug with v1.1.1.0 that did not recognize the Resources directory by the timestap, so it has been simplified to day/month/year.
- Fixed a bug where the HashCopier feature would delete Backup directories.