### PR TITLE
fix: correct typo in 'OTHER APPS' label

### DIFF
--- a/AssetsManager/Views/HomeWindow.xaml
+++ b/AssetsManager/Views/HomeWindow.xaml
@@ -110,7 +110,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/> <!-- Hero -->
                     <RowDefinition Height="Auto"/> <!-- Main Grid -->
-                    <RowDefinition Height="Auto"/> <!-- Others Apps -->
+                    <RowDefinition Height="Auto"/> <!-- Other Apps -->
                 </Grid.RowDefinitions>
 
                 <!-- 1. HERO SECTION -->
@@ -226,9 +226,9 @@
                     </Grid>
                 </Grid>
 
-                <!-- 3. OTHERS APPS SECTION -->
+                <!-- 3. OTHER APPS SECTION -->
                 <StackPanel Grid.Row="2">
-                    <TextBlock Text="OTHERS APPS" Style="{StaticResource ToolSectionLabel}" Margin="8,0,0,12"/>
+                    <TextBlock Text="OTHER APPS" Style="{StaticResource ToolSectionLabel}" Margin="8,0,0,12"/>
                     <StackPanel Orientation="Horizontal">
                         <!-- Notepad -->
                         <Button Width="200" Height="100" Style="{StaticResource DashboardTileStyle}" Click="Notepad_Click" Tag="{StaticResource AccentOrange}" Margin="0,0,8,0">


### PR DESCRIPTION
fixed typo: Others Apps -> Other Apps